### PR TITLE
fix: quest progression from 10th quest onward in the same questline

### DIFF
--- a/src/server-emulator/hiperesp/server/models/CharacterModel.php
+++ b/src/server-emulator/hiperesp/server/models/CharacterModel.php
@@ -109,7 +109,7 @@ class CharacterModel extends Model {
 
     public function setQuestString(CharacterVO $char, int $index, int $value): void {
         $questString = $char->quests;
-        $questString[$index] = $value;
+        $questString[$index] = strtoupper(dechex($value));
         $this->storage->update(self::COLLECTION, [
             'id' => $char->id,
             'quests' => $questString


### PR DESCRIPTION
Fix quest progression from 10th quest onward, a good test example would be ravenloss saga, which will reset on relogin if user complete the "Altar Hill" quest