### PR TITLE
Adds missing classes + items

### DIFF
--- a/src/server-emulator/hiperesp/data/class/merged.json
+++ b/src/server-emulator/hiperesp/data/class/merged.json
@@ -370,6 +370,16 @@
         "weaponId": 9800184
     },
     {
+        "id": 47,
+        "name": "GPS 2.0",
+        "element": "Metal",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "GPSr2-r2.swf",
+        "savable": 2791,
+        "armorId": 9800187,
+        "weaponId": 9800186
+    },
+    {
         "id": 49,
         "name": "Xan",
         "element": "Fire",
@@ -448,6 +458,16 @@
         "savable": 0,
         "armorId": 9800225,
         "weaponId": 9800224
+    },
+    {
+        "id": 57,
+        "name": "Kathool Adept",
+        "element": "Darkness",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Helmet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-adept-r7.swf",
+        "savable": 3825,
+        "armorId": 9800227,
+        "weaponId": 9800226
     },
     {
         "id": 58,
@@ -530,6 +550,16 @@
         "weaponId": 9800276
     },
     {
+        "id": 70,
+        "name": "Entropy",
+        "element": "Darkness",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-entropy-r21.swf",
+        "savable": 5997,
+        "armorId": 9800279,
+        "weaponId": 9800278
+    },
+    {
         "id": 71,
         "name": "Alexander",
         "element": "Ice",
@@ -578,6 +608,16 @@
         "savable": 2,
         "armorId": 9800305,
         "weaponId": 9800304
+    },
+    {
+        "id": 77,
+        "name": "Pyromancer",
+        "element": "Fire",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Helmet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-pyromancer-r15.swf?ver=5",
+        "savable": 7660,
+        "armorId": 9800307,
+        "weaponId": 9800306
     },
     {
         "id": 78,
@@ -650,6 +690,16 @@
         "weaponId": 9800340
     },
     {
+        "id": 86,
+        "name": "ChronoZ",
+        "element": "Ice",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-ChronoZ-r8.swf?ver=3",
+        "savable": 11730,
+        "armorId": 9800343,
+        "weaponId": 9800342
+    },
+    {
         "id": 87,
         "name": "Edd Disguise",
         "element": "Metal",
@@ -688,6 +738,16 @@
         "savable": 0,
         "armorId": 9800361,
         "weaponId": 9800360
+    },
+    {
+        "id": 91,
+        "name": "Icebound Revenant",
+        "element": "Ice",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-IceboundRevenant-r3.swf",
+        "savable": 12250,
+        "armorId": 9800363,
+        "weaponId": 9800362
     },
     {
         "id": 93,
@@ -820,6 +880,16 @@
         "weaponId": 9800424
     },
     {
+        "id": 108,
+        "name": "DoomKnight",
+        "element": "Darkness",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-DoomKnightRevamp-r14.swf?ver=2",
+        "savable": 14819,
+        "armorId": 9800435,
+        "weaponId": 9800434
+    },
+    {
         "id": 109,
         "name": "Beast Master",
         "element": "Nature",
@@ -848,6 +918,16 @@
         "savable": 0,
         "armorId": 9800445,
         "weaponId": 9800444
+    },
+    {
+        "id": 112,
+        "name": "Chaosweaver",
+        "element": "Metal",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-chaosweaver-r4.swf",
+        "savable": 19072,
+        "armorId": 9800447,
+        "weaponId": 9800446
     },
     {
         "id": 113,
@@ -880,6 +960,16 @@
         "weaponId": 9800460
     },
     {
+        "id": 116,
+        "name": "Ancient Exosuit",
+        "element": "Energy",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-playerExoSuit.swf",
+        "savable": 14441,
+        "armorId": 9800463,
+        "weaponId": 9800462
+    },
+    {
         "id": 117,
         "name": "x",
         "element": "Darkness",
@@ -888,6 +978,16 @@
         "savable": 0,
         "armorId": 9800469,
         "weaponId": 9800468
+    },
+    {
+        "id": 118,
+        "name": "Archivist",
+        "element": "Good",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-archivist-r10.swf",
+        "savable": 14969,
+        "armorId": 9800471,
+        "weaponId": 9800470
     },
     {
         "id": 119,
@@ -990,6 +1090,36 @@
         "weaponId": 9800512
     },
     {
+        "id": 129,
+        "name": "Shadow Warrior",
+        "element": "Metal",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-shadowwarrior.swf?ver=2",
+        "savable": 16024,
+        "armorId": 9800515,
+        "weaponId": 9800514
+    },
+    {
+        "id": 130,
+        "name": "Shadow Mage",
+        "element": "Nature",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-shadowmage.swf?ver=2",
+        "savable": 16023,
+        "armorId": 9800517,
+        "weaponId": 9800516
+    },
+    {
+        "id": 131,
+        "name": "Shadow Rogue",
+        "element": "Metal",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-shadowrogue-r3.swf",
+        "savable": 16022,
+        "armorId": 9800519,
+        "weaponId": 9800518
+    },
+    {
         "id": 132,
         "name": "Paladin of Light",
         "element": "Light",
@@ -1048,6 +1178,16 @@
         "savable": 0,
         "armorId": 9800553,
         "weaponId": 9800552
+    },
+    {
+        "id": 139,
+        "name": "Necro Paragon",
+        "element": "Darkness",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-necroparagon-r8.swf",
+        "savable": 17776,
+        "armorId": 9800555,
+        "weaponId": 9800554
     },
     {
         "id": 141,
@@ -1110,6 +1250,16 @@
         "weaponId": 9800584
     },
     {
+        "id": 147,
+        "name": "Dreaming Togslayer",
+        "element": "Ice",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-Togslayernew.swf?ver=1",
+        "savable": 18055,
+        "armorId": 9800587,
+        "weaponId": 9800586
+    },
+    {
         "id": 149,
         "name": "Sleepy Hero",
         "element": "None",
@@ -1138,6 +1288,16 @@
         "savable": 0,
         "armorId": 9800613,
         "weaponId": 9800612
+    },
+    {
+        "id": 154,
+        "name": "Student",
+        "element": "Metal",
+        "equippable": "Sword,Mace,Dagger,Axe,Ring,Necklace,Staff,Belt,Earring,Bracer,Pet,Cape,Wings,Helmet,Armor,Wand,Scythe,Trinket,Artifact",
+        "swf": "class-school-r2.swf?ver=2",
+        "savable": 20175,
+        "armorId": 9800615,
+        "weaponId": 9800614
     },
     {
         "id": 155,


### PR DESCRIPTION
Adds the missing classes from #63 along with all of the required items for them 9800186, 9800187 etc.
Also includes DoomKnight V2, ChronoZ (not reforged), and Archivist (not reforged).

Adds all DoomKnight items (DoomKnight Helm, DoomKnight Cloak, Necrotic Sword of Doom) at all of their different levels (1, 10, 20, 30, 40, 50, 60, 70, 80, 90)

I will hopefully be adding DoomKnight V1, Chronomancer, Chronocorruptor, TimeKiller, Avatar of Time, ShadowWalker of Time, and all Epoch variants in the coming days.