### PR TITLE
Adds Dragon PVP

### DIFF
--- a/src/server-emulator/hiperesp/server/controllers/game/PvpController.php
+++ b/src/server-emulator/hiperesp/server/controllers/game/PvpController.php
@@ -31,7 +31,7 @@ class PvpController extends Controller {
 		
 		return PvpProjection::instance()->loaded($player);
 	}
-	
+
 	#[Request(
 		endpoint: '/cf-loadpvpchar.asp',
 		inputType: Input::NINJA2,
@@ -45,5 +45,22 @@ class PvpController extends Controller {
 		}
 		
 		return PvpProjection::instance()->loaded($player);
+	}
+
+	#[Request(
+		endpoint: '/cf-loadpvpdragon.asp',
+		inputType: Input::NINJA2,
+        outputType: Output::XML
+	)]
+	public function loadDragonRider(\SimpleXMLElement $input): \SimpleXMLElement {
+		$char = $this->characterService->auth($input);
+
+		$dragonRider = $this->pvpService->loadDragonRider($char);
+		if ($dragonRider == null)
+		{
+			return new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><PvPDragon xmlns:sql="urn:schemas-microsoft-com:xml-sql"/>');
+		}
+
+		return PvpProjection::instance()->loadedDragonRider($dragonRider);
 	}
 }

--- a/src/server-emulator/hiperesp/server/models/CharacterModel.php
+++ b/src/server-emulator/hiperesp/server/models/CharacterModel.php
@@ -121,6 +121,13 @@ class CharacterModel extends Model {
         return new CharacterVO($char);
     }
 
+	public function addDragon(CharacterVO $char): void {
+        $this->storage->update(self::COLLECTION, [
+            'id' => $char->id,
+            'hasDragon' => 1
+        ]);
+    }
+
     public function charge(CharacterVO $char, Purchasable $item): void {
         $this->storage->update(self::COLLECTION, [
             'id' => $char->id,

--- a/src/server-emulator/hiperesp/server/models/PvpModel.php
+++ b/src/server-emulator/hiperesp/server/models/PvpModel.php
@@ -12,7 +12,7 @@ class PvpModel extends Model {
     const COLLECTION = 'char';
 
     #[Inject] private SettingsVO $settings;
-	
+
 	public function loadRandom(CharacterVO $char, int $level, int $charId): ?CharacterVO {
 		$gap = 1;
 		$maxGap = 30;
@@ -39,7 +39,7 @@ class PvpModel extends Model {
 
 		return null; // handled by game client - no character found
 	}
-	
+
 	public function loadChar(int $charId): ?CharacterVO {		
 		$player = $this->storage->select(self::COLLECTION, ['id' => $charId]);
 		
@@ -48,6 +48,35 @@ class PvpModel extends Model {
 		}
 		
 		return null; //handled by the game client - Invalid ID - No character found..
+	}
+
+	public function loadDragonRider(CharacterVO $char): ?CharacterVO {		
+		$gap = 1;
+		$maxGap = 89;
+
+		$userId = $char->userId;
+		$level = $char->level;
+
+		while ($gap <= $maxGap) {
+			$minLevel = max(1, $level - $gap);
+			$maxLevel = min(90, $level + $gap);
+
+			$matches = $this->storage->select(self::COLLECTION, [
+				'level' => ['BETWEEN' => [$minLevel, $maxLevel]],
+				'hasDragon' => 1,
+				'userId' => ['!=' => $userId] // exclude own characters
+			], 1000);
+
+			if (!empty($matches)) {
+				$matches = array_values($matches);
+				$dragonRider = $matches[array_rand($matches)];
+				return new CharacterVO($dragonRider);
+			}
+
+			$gap++;
+		}
+
+		return null; // handled by game client - no character found
 	}
 
 }

--- a/src/server-emulator/hiperesp/server/projection/CharacterProjection.php
+++ b/src/server-emulator/hiperesp/server/projection/CharacterProjection.php
@@ -37,7 +37,7 @@ class CharacterProjection extends Projection {
     }
 
     public function loaded(CharacterVO $char): \SimpleXMLElement {
-        $xml = new \SimpleXMLElement('<character/>');
+        $xml = new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><character xmlns:sql="urn:schemas-microsoft-com:xml-sql"/>');
         $charEl = $xml->addChild('character');
         $charEl->addAttribute('CharID', $char->id);
         $charEl->addAttribute('strCharacterName', $char->name);

--- a/src/server-emulator/hiperesp/server/projection/PvpProjection.php
+++ b/src/server-emulator/hiperesp/server/projection/PvpProjection.php
@@ -160,4 +160,92 @@ class PvpProjection extends Projection {
         return $xml;
     }
 
+	public function loadedDragonRider(CharacterVO $char): \SimpleXMLElement {
+        $xml = new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><PvPDragon xmlns:sql="urn:schemas-microsoft-com:xml-sql"/>');
+        $charEl = $xml->addChild('character');
+        $charEl->addAttribute('CharID', $char->id);
+        $charEl->addAttribute('strCharacterName', $char->name);
+        $charEl->addAttribute('intLevel', $char->level);
+        $charEl->addAttribute('intExp', $char->experience);
+        $charEl->addAttribute('intHP', $char->hitPoints);
+        $charEl->addAttribute('intMP', $char->manaPoints);
+        $charEl->addAttribute('intGold', $char->gold);
+        $charEl->addAttribute('intCoins', $char->coins);
+        $charEl->addAttribute('strGender', $char->gender);
+        $charEl->addAttribute('intColorHair', \hexdec($char->colorHair));
+        $charEl->addAttribute('intColorSkin', \hexdec($char->colorSkin));
+        $charEl->addAttribute('intColorBase', \hexdec($char->colorBase));
+        $charEl->addAttribute('intColorTrim', \hexdec($char->colorTrim));
+        $charEl->addAttribute('intStr', $char->strength);
+        $charEl->addAttribute('intDex', $char->dexterity);
+        $charEl->addAttribute('intInt', $char->intelligence);
+        $charEl->addAttribute('intLuk', $char->luck);
+        $charEl->addAttribute('intCha', $char->charisma);
+        $charEl->addAttribute('intEnd', $char->endurance);
+        $charEl->addAttribute('intWis', $char->wisdom);
+        $charEl->addAttribute('strArmor', $char->armor);
+        $charEl->addAttribute('intExpToLevel', $char->experienceToLevel);
+
+        $race = $char->getRace();
+        $charEl->addAttribute('RaceID', $race->id);
+        $charEl->addAttribute('strRaceName', $race->name);
+
+        $class = $char->getClass();
+        $charEl->addAttribute('ClassID', 13);
+        $charEl->addAttribute('strClassName', "DragonRider");
+        $charEl->addAttribute('strClassFileName', "class-dragonrider-NEWr4.swf?ver=1");
+
+        $armor = $class->getArmor();
+        $charEl->addAttribute('strArmorResists', "");
+        $charEl->addAttribute('intDefMelee', 5);
+        $charEl->addAttribute('intDefPierce', 5);
+        $charEl->addAttribute('intDefMagic', 5);
+        $charEl->addAttribute('intParry', 0);
+        $charEl->addAttribute('intDodge', 0);
+        $charEl->addAttribute('intBlock', 0);
+
+        $weapon = $class->getWeapon();
+        $charEl->addAttribute('strWeaponResists', "");
+        $charEl->addAttribute('strType', "Melee");
+        $charEl->addAttribute('strItemType', "Scythe");
+        $charEl->addAttribute('intCrit', 5);
+        $charEl->addAttribute('intDmgMin', 700);
+        $charEl->addAttribute('intDmgMax', 800);
+        $charEl->addAttribute('intBonus', 0);
+        $charEl->addAttribute('strEquippable', "");
+
+        $hair = $char->getHair();
+        $charEl->addAttribute('strHairFileName', $hair->swf);
+        $charEl->addAttribute('intHairFrame', 1);
+        $charEl->addAttribute('strElement', "None");
+
+        $dragon = $char->getDragon();
+		if(isset($dragon['id'])) {
+            $dragonEl = $charEl->addChild('dragon');
+			$dragonEl->addAttribute('idCore_CharDragons', $dragon['id']);
+			$dragonEl->addAttribute('strName', $dragon['name']);
+			$dragonEl->addAttribute('intHeal', $dragon['heal']);
+			$dragonEl->addAttribute('intMagic', $dragon['magic']);
+			$dragonEl->addAttribute('intMelee', $dragon['melee']);
+			$dragonEl->addAttribute('intBuff', $dragon['buff']);
+			$dragonEl->addAttribute('intDebuff', $dragon['debuff']);
+			$dragonEl->addAttribute('intColorDskin', $dragon['colorDSkin']);
+			$dragonEl->addAttribute('intColorDeye', $dragon['colorDEye']);
+			$dragonEl->addAttribute('intColorDhorn', $dragon['colorDHorn']);
+			$dragonEl->addAttribute('intColorDwing', $dragon['colorDWing']);
+			$dragonEl->addAttribute('intHeadID', $dragon['headId']);
+			$dragonEl->addAttribute('strHeadFilename', $dragon['headFileName']);
+			$dragonEl->addAttribute('intWingID', $dragon['wingId']);
+			$dragonEl->addAttribute('strWingFilename', $dragon['wingFileName']);
+			$dragonEl->addAttribute('intTailID', $dragon['tailId']);
+			$dragonEl->addAttribute('strTailFilename', $dragon['tailFileName']);
+			$dragonEl->addAttribute('strElement', $dragon['element']);
+			$dragonEl->addAttribute('intColorDelement', $dragon['colorDElement']);
+        }
+		else {
+			return new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><PvPDragon xmlns:sql="urn:schemas-microsoft-com:xml-sql"/>');
+		}
+        return $xml;
+    }
+
 }

--- a/src/server-emulator/hiperesp/server/services/DragonService.php
+++ b/src/server-emulator/hiperesp/server/services/DragonService.php
@@ -3,6 +3,7 @@ namespace hiperesp\server\services;
 
 use hiperesp\server\attributes\Inject;
 use hiperesp\server\exceptions\DFException;
+use hiperesp\server\models\CharacterModel;
 use hiperesp\server\models\DragonModel;
 use hiperesp\server\models\LogsModel;
 use hiperesp\server\vo\CharacterVO;
@@ -10,12 +11,14 @@ use hiperesp\server\vo\SettingsVO;
 
 class DragonService extends Service {
 
+    #[Inject] private CharacterModel $characterModel;
     #[Inject] private DragonModel $dragonModel;
     #[Inject] private LogsModel $logsModel;
 	#[Inject] private SettingsVO $settings;
 
 
 	public function hatchDragon(CharacterVO $char): array {
+		$this->characterModel->addDragon($char);
 		return $this->dragonModel->hatchDragon($char);
     }
 	

--- a/src/server-emulator/hiperesp/server/services/PvpService.php
+++ b/src/server-emulator/hiperesp/server/services/PvpService.php
@@ -17,9 +17,13 @@ class PvpService extends Service {
     public function loadRandom(CharacterVO $char, int $level, int $charId): ?CharacterVO {
 		return $this->pvpModel->loadRandom($char, $level, $charId);
     }
-	
+
 	public function loadChar(int $charId): ?CharacterVO {
 		return $this->pvpModel->loadChar($charId);
+    }
+
+	public function loadDragonRider(CharacterVO $char): ?CharacterVO {
+		return $this->pvpModel->loadDragonRider($char);
     }
 
 }

--- a/src/server-emulator/hiperesp/server/storage/Definition.php
+++ b/src/server-emulator/hiperesp/server/storage/Definition.php
@@ -379,6 +379,7 @@ final class Definition {
                 "coins"             => [ 'INTEGER', 'DEFAULT' => 0 ],
 
                 "dragonAmulet"      => [ 'INTEGER', 'DEFAULT' => 0 ],
+                "hasDragon"			=> [ 'INTEGER', 'DEFAULT' => 0 ],
                 "bagSlots"			=> [ 'INTEGER', 'DEFAULT' => 30 ],
                 "bankSlots"			=> [ 'INTEGER', 'DEFAULT' => 0 ],
                 "pvpStatus"         => [ 'INTEGER', 'DEFAULT' => 0 ],

--- a/src/server-emulator/hiperesp/server/vo/CharacterVO.php
+++ b/src/server-emulator/hiperesp/server/vo/CharacterVO.php
@@ -47,6 +47,7 @@ class CharacterVO extends ValueObject implements Bannable {
     public readonly int $coins;
 
     public readonly bool $dragonAmulet;
+    public readonly bool $hasDragon;
     public readonly int $bagSlots;
     public readonly int $bankSlots;
     public readonly bool $pvpStatus;


### PR DESCRIPTION
The original server only allows you to battle an array of characters (137382, 2, 22, 35, 202957, 154640) Artix, Cysero, fisn, Zhoom, Rolith, and Charis.
I've allowed battles against any character.
Only problem is the enemy player's dragon copies your dragon's colors (except the skin color for some reason), but all other customizations remain intact.

I have added 'hasDragon' to the 'char' storage definition. 'hasDragon' is set to 1 when cf-dragonhatch.asp is called.

Can close #99 